### PR TITLE
use syntax/strip-context

### DIFF
--- a/sweet-exp/modern.rkt
+++ b/sweet-exp/modern.rkt
@@ -63,6 +63,7 @@
          syntax/readerr
          syntax/stx
          syntax/srcloc
+         syntax/strip-context
          "read-sig.rkt"
          "util.rkt")
 
@@ -308,7 +309,10 @@
     (set! source-name (object-name port)))
   (parameterize ([current-source-name source-name]
                  [current-input-port port])
-    (modern-read2 port)))
+    (define stx (modern-read2 port))
+    (if (and (syntax? stx) (not (dot? stx)))
+        (strip-context stx)
+        stx)))
 
 ;; modern-read2 : input-port? -> syntax?
 ;; Read using "modern Lisp notation".

--- a/sweet-exp/run-tests.rkt
+++ b/sweet-exp/run-tests.rkt
@@ -17,6 +17,7 @@
          "tests/typed.rkt"
          "tests/typed2.rkt"
          "tests/whitespace.rkt"
+         "tests/strip-context/use-m.rkt"
          "tests/sweet-test-run.rkt")
 
 (sweet-test "tests/sweet-testsuite")

--- a/sweet-exp/sugar.rkt
+++ b/sweet-exp/sugar.rkt
@@ -18,6 +18,7 @@
          syntax/parse
          syntax/stx
          syntax/srcloc
+         syntax/strip-context
          syntax/readerr
          "read-sig.rkt"
          "util.rkt")
@@ -257,7 +258,10 @@
     (set! source-name (object-name port)))
   (parameterize ([current-source-name source-name]
                  [current-input-port port])
-    (sugar-start-expr)))
+    (define stx (sugar-start-expr))
+    (if (and (syntax? stx) (not (dot? stx)))
+        (strip-context stx)
+        stx)))
 
 
 (define (sugar-filter)

--- a/sweet-exp/tests/strip-context/m.rkt
+++ b/sweet-exp/tests/strip-context/m.rkt
@@ -1,0 +1,5 @@
+#lang sweet-exp racket/base
+provide m
+require (for-syntax racket/base)
+define-syntax (m stx)
+  #'{1 + 2}

--- a/sweet-exp/tests/strip-context/use-m.rkt
+++ b/sweet-exp/tests/strip-context/use-m.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(require "m.rkt" rackunit)
+(check-equal? (m) 3)


### PR DESCRIPTION
This fixes a bug that I was getting with macros that expanded to syntax that was originally written as a curly infix expression.  
