### PR TITLE
fix problem with case-lambda with a () case

### DIFF
--- a/sweet-exp/run-tests.rkt
+++ b/sweet-exp/run-tests.rkt
@@ -3,6 +3,7 @@
 (require "tests/2htdp.rkt"
          "tests/335.rkt"
          "tests/bad-close-error.rkt"
+         "tests/case-lambda.rkt"
          "tests/define-syntax-rule.rkt"
          "tests/fib.rkt"
          "tests/hash.rkt"

--- a/sweet-exp/sugar.rkt
+++ b/sweet-exp/sugar.rkt
@@ -113,15 +113,9 @@
   (syntax-parse stx
     [((~literal group) e ...)
      (datum->syntax stx (stx-cdr stx) stx)]
-    [(() e ...)
-     (datum->syntax stx (stx-cdr stx) stx)]
-    [((q:quote-like) e e1 ...)
-     (datum->syntax stx (cons #'q (stx-cdr stx)) stx)]
     [((e ...) e1 ...)
      (datum->syntax stx (cons (clean (stx-car stx)) (stx-cdr stx)) stx)]
-    [(e ...) stx]
-    [e stx]
-    [() stx]))
+    [_ stx]))
 
 ;; indent -> syntax?
 ;; Reads all subblocks of a block

--- a/sweet-exp/tests/case-lambda.rkt
+++ b/sweet-exp/tests/case-lambda.rkt
@@ -1,0 +1,11 @@
+#lang sweet-exp racket
+
+require rackunit
+
+define f
+  case-lambda
+    ()
+      0
+
+check-equal? f() 0
+


### PR DESCRIPTION
To do this, I deleted some cases in the `clean` function that didn't seem to be needed, one of which was causing this problem.

Why were those cases there?  Were they needed for something?  All the tests still pass (except the quasiquote ones that were always failing), but I still want to ask.
