### PR TITLE
Improve spec conformance and usability

### DIFF
--- a/sweet-exp-lib/sweet-exp/sugar.rkt
+++ b/sweet-exp-lib/sweet-exp/sugar.rkt
@@ -113,7 +113,7 @@
                   (~literal unquote))))
 
   (syntax-parse stx
-    [((~literal group) e ...)
+    [((~or (~literal group) (~literal \\)) e ...)
      (clean (datum->syntax stx (stx-cdr stx) stx))]
     [(e1 ... (~and $ (~datum $)) e2 ...)
      #:do [(define e2-lst (syntax->list #'(e2 ...)))]

--- a/sweet-exp-test/sweet-exp/tests/sweet-testsuite
+++ b/sweet-exp-test/sweet-exp/tests/sweet-testsuite
@@ -208,13 +208,24 @@ a b c
 group
   hello
 
+(hello)
+\\
+  hello
+
 ((hello there))
 group
+  hello there
+
+((hello there))
+\\
   hello there
 
 
 (hi group)
 hi group
+
+(hi \\)
+hi \\
 
 (a (b c) (d e))
 a
@@ -245,9 +256,20 @@ x
   group
      y
 
+(x (y))
+x
+  \\
+     y
+
 (let ((x 1) (y 2)))
 let
   group
+    x 1
+    y 2
+
+(let ((x 1) (y 2)))
+let
+  \\
     x 1
     y 2
 
@@ -280,6 +302,11 @@ cond
 `(,@x)
 `group
   ,@x
+
+`(,@x)
+`
+  \\
+    ,@x
 
 (a . b)
 a . b

--- a/sweet-exp-test/sweet-exp/tests/sweet.rkt
+++ b/sweet-exp-test/sweet-exp/tests/sweet.rkt
@@ -41,6 +41,17 @@ define (g a . args) list(a args)
 
 check-equal? (g 1 2 3) (list 1 (list 2 3))
 
+;; Check \\ grouping behavior
+let  
+  \\  
+    a 1
+      ;; This is a comment
+      ;; This, too, is a comment
+    b 2      
+  check-equal? 
+    * a b
+    2
+
 let
   group
     | | 5


### PR DESCRIPTION
Implement \\ (in spec but not implementation), ignore whitespace lines (not sure if that's in the spec but using this library is annoying otherwise)