### PR TITLE
Remove unnecessary paren-shape calls

### DIFF
--- a/sweet-exp-lib/sweet-exp/modern.rkt
+++ b/sweet-exp-lib/sweet-exp/modern.rkt
@@ -347,12 +347,12 @@
             (read-char port)
             (define lst (my-read-delimited-list #\) port))
             (define end-pos (port-pos port))
-            (paren-shape (make-stx lst ln col pos (- end-pos pos)) #\( )])]
+            (make-stx lst ln col pos (- end-pos pos))])]
     [(rt-char=? c #\[ )
      (read-char port)
      (define lst (my-read-delimited-list #\] port))
      (define end-pos (port-pos port))
-     (paren-shape (make-stx lst ln col pos (- end-pos pos)) #\[ )]
+     (make-stx lst ln col pos (- end-pos pos))]
     [(rt-char=? c #\{ )
      (read-char port)
      (define lst (my-read-delimited-list #\} port))


### PR DESCRIPTION
I found that it does't work when using `sweet-racket` with `hackett` together like below.

``` racket
#lang sweet-racket hackett
```

I digged into the code and found the issue is caused by those unnecessary
`paren-shape` call. 

After removing them, everything is fine.