### PR TITLE
Added \\ processing, fixed parsing bug

### DIFF
--- a/sweet-exp-lib/sweet-exp/sugar.rkt
+++ b/sweet-exp-lib/sweet-exp/sugar.rkt
@@ -115,6 +115,12 @@
   (syntax-parse stx
     [((~or (~literal group) (~literal \\)) e ...)
      (clean (datum->syntax stx (stx-cdr stx) stx))]
+    [(before ... (e1 (~literal \\) e2) after ...)
+     (clean (datum->syntax stx (syntax-e #'(before ... e1 e2 after ...)) stx))]
+    [(before ... (e1 ... (~literal \\) e2) after ...)
+     (clean (datum->syntax stx (syntax-e #'(before ... (e1 ...) e2 after ...)) stx))]
+    [(before ... (e1 ... (~literal \\) e2 ...) after ...)
+     (clean (datum->syntax stx (syntax-e #'(before ... (e1 ...) (e2 ...) after ...)) stx))]
     [(e1 ... (~and $ (~datum $)) e2 ...)
      #:do [(define e2-lst (syntax->list #'(e2 ...)))]
      #:with e2s (cond [(= (length e2-lst) 1) (car e2-lst)]
@@ -184,7 +190,7 @@
      (match-define (cons new-level rest) (readblock level))
      (define end-pos (port-pos (current-input-port)))
      (cond [(eof-object? first) (cons new-level first)]
-           [(eof-object? rest) (cons new-level first)]
+           [(eof-object? rest) (cons new-level (make-stx (list first) ln col pos (- end-pos pos)))]
            [(dot? first)
             (match (syntax->list rest)
               [(list) (cons new-level first)]


### PR DESCRIPTION
There was a bug.
```
list 1 2 3
  list 4 5
```
raised a error, because it was parsed as (list 1 2 3 (list 4 . 5))
Now it's fixed.

And now \\ can be not only an empty head, but also can be used to split a list.
```
let
  \\
    a 1 \\ b 2 \\ c 3
  {a + b + c}
```
or
```
map $ lambda (x) {1 / x} \\ '(1 2 3)
```