### PR TITLE
Add sweet-exp/reader module

### DIFF
--- a/sweet-exp-lib/sweet-exp/main.rkt
+++ b/sweet-exp-lib/sweet-exp/main.rkt
@@ -2,42 +2,6 @@
 
 ;; Sweet expressions
 
-(module link-reader racket/base
-
-  ;; This module handles the linking of units to construct
-  ;; a sweet expression reader.
-
-  (require racket/unit
-           "read-sig.rkt"
-           "sweet.rkt")
-
-  (provide sweet-link)
-
-  ;; Procedure Procedure -> Procedure Procedure
-  ;; Constructs sweet readers from the given underlying readers
-  (define (sweet-link read read-syntax)
-
-    (define-unit underlying-read@
-      (import)
-      (export (rename read^ [-read read]
-                            [-read-syntax read-syntax]))
-
-      (define -read read)
-      (define -read-syntax read-syntax))
-
-    (define-values/invoke-unit
-      (compound-unit
-        (import)
-        (export S)
-
-        (link [((R : read^)) underlying-read@]
-              [((S : read^)) sweet@ R]))
-
-      (import)
-      (export (prefix sweet- read^)))
-
-    (values sweet-read sweet-read-syntax)))
-
 (module language-info racket/base
   (provide get-language-info)
   (define (get-language-info data)
@@ -52,13 +16,11 @@
   ;; This module provides runtime configuration, e.g., for
   ;; using sweet-exp based modules in DrRacket
 
-  (require (submod ".." link-reader))
+  (require "reader.rkt")
 
   (provide configure)
 
   (define (configure data)
-    (define-values (_ sweet-read-syntax)
-      (sweet-link read read-syntax))
     (current-read-interaction sweet-read-syntax)))
 
 (module reader syntax/module-reader
@@ -68,9 +30,7 @@
   #:info get-info
   #:language-info #((submod sweet-exp language-info) get-language-info #f)
 
-  (require (submod ".." link-reader))
-  (define-values (sweet-read sweet-read-syntax)
-    (sweet-link read read-syntax))
+  (require "reader.rkt")
 
   (define (get-info key default f)
     (define (fallback) (f key default))

--- a/sweet-exp-lib/sweet-exp/reader.rkt
+++ b/sweet-exp-lib/sweet-exp/reader.rkt
@@ -1,0 +1,46 @@
+#lang racket/base
+
+(provide sweet-read
+         sweet-read-syntax)
+
+(module link-reader racket/base
+
+  ;; This module handles the linking of units to construct
+  ;; a sweet expression reader.
+
+  (require racket/unit
+           "read-sig.rkt"
+           "sweet.rkt")
+
+  (provide sweet-link)
+
+  ;; Procedure Procedure -> Procedure Procedure
+  ;; Constructs sweet readers from the given underlying readers
+  (define (sweet-link read read-syntax)
+
+    (define-unit underlying-read@
+      (import)
+      (export (rename read^ [-read read]
+                            [-read-syntax read-syntax]))
+
+      (define -read read)
+      (define -read-syntax read-syntax))
+
+    (define-values/invoke-unit
+      (compound-unit
+        (import)
+        (export S)
+
+        (link [((R : read^)) underlying-read@]
+              [((S : read^)) sweet@ R]))
+
+      (import)
+      (export (prefix sweet- read^)))
+
+    (values sweet-read sweet-read-syntax)))
+
+(require (submod "." link-reader))
+
+(define-values (sweet-read sweet-read-syntax)
+  (sweet-link read read-syntax))
+

--- a/sweet-exp-test/sweet-exp/tests/bad-close-error.rkt
+++ b/sweet-exp-test/sweet-exp/tests/bad-close-error.rkt
@@ -1,10 +1,7 @@
 #lang racket/base
 
 (require rackunit
-         (submod sweet-exp link-reader))
-
-(define-values (sweet-read sweet-read-syntax)
-  (sweet-link read read-syntax))
+         sweet-exp/reader)
 
 (check-exn exn:fail:read?
            (λ () (sweet-read (open-input-string ")"))))

--- a/sweet-exp/sweet-exp/sweet.scrbl
+++ b/sweet-exp/sweet-exp/sweet.scrbl
@@ -1,7 +1,11 @@
 #lang scribble/doc
 
 @(require scribble/manual
-          (for-label racket/base sweet-exp))
+          scribble/example
+          (for-label racket/base
+                     racket/contract/base
+                     sweet-exp
+                     sweet-exp/reader))
 
 @title{Sweet: an alternative to s-expressions}
 @author[(author+email "Asumu Takikawa" "asumu@racket-lang.org")]
@@ -53,3 +57,19 @@ Or alternatively:
 
 Known issues: quasi-quotation combined with grouping does not
 behave according to the specification.
+
+@section{Sweet reading functions}
+
+@defmodule[sweet-exp/reader]
+
+@deftogether[[
+  @defproc[(sweet-read [in input-port? (current-input-port)]) any]
+  @defproc[(sweet-read-syntax [source-name any/c (object-name in)]
+                              [in input-port? (current-input-port)])
+           (or/c syntax? eof-object?)]]]{
+These procedures implement the @racketmodname[sweet-exp] reader.
+
+@examples[
+  (require sweet-exp/reader)
+  (sweet-read (open-input-string "printf(\"Hello\")"))
+]}


### PR DESCRIPTION
Fixes #49 by adding a `sweet-exp/reader` providing `sweet-read` and `sweet-read-syntax`.

```racket
> (require sweet-exp/reader)
> (sweet-read (open-input-string "printf(\"Hello\")"))
'(printf "Hello")
```